### PR TITLE
Use S3_BUCKET if set for processing payment CSV

### DIFF
--- a/app/models/payment_history/csv_importer.rb
+++ b/app/models/payment_history/csv_importer.rb
@@ -147,7 +147,7 @@ class PaymentHistory::CsvImporter
     temp_files[:s3_download] = Tempfile.new("s3_download")
     s3 = Aws::S3::Client.new
     s3.get_object({
-      bucket: "partner-metrics",
+      bucket: ENV.fetch("S3_BUCKET", "partner-metrics"),
       key: filename
     },
       target: temp_files[:s3_download].path)


### PR DESCRIPTION
Just sharing a small change I needed to make to get this to work locally. The code to download the payment history CSV from S3 still appeared to use the hard-coded `partner-metrics` bucket.

I've set the fallback to `partner-metrics` if the environmental variable isn't set but not sure if that's necessary