### PR TITLE
WIP: Turbo 8 morphing frames

### DIFF
--- a/app/views/metrics/_filter.html.erb
+++ b/app/views/metrics/_filter.html.erb
@@ -1,7 +1,7 @@
   <%= form_tag(
     url_for(action: action_name, charge_type: filter.charge_type),
     method: :get,
-    data: {controller: "filters", turbo_frame: :metrics, turbo_action: :advance},
+    data: {controller: "filters"},
   ) do %>
 
     <%= hidden_field_tag :chart, filter.chart %>

--- a/app/views/metrics/_filter.html.erb
+++ b/app/views/metrics/_filter.html.erb
@@ -1,7 +1,7 @@
   <%= form_tag(
     url_for(action: action_name, charge_type: filter.charge_type),
     method: :get,
-    data: {controller: "filters"},
+    data: {controller: "filters", turbo_action: :advance},
   ) do %>
 
     <%= hidden_field_tag :chart, filter.chart %>

--- a/app/views/metrics/_forecasts_form.html.erb
+++ b/app/views/metrics/_forecasts_form.html.erb
@@ -5,7 +5,8 @@
     data: {
       controller: "submittable",
       submittable_target: "form",
-      action: "change->submittable#submit"
+      action: "change->submittable#submit",
+      turbo_action: :advance
     }
   ) do |form| %>
 

--- a/app/views/metrics/_forecasts_form.html.erb
+++ b/app/views/metrics/_forecasts_form.html.erb
@@ -5,9 +5,7 @@
     data: {
       controller: "submittable",
       submittable_target: "form",
-      action: "change->submittable#submit",
-      turbo_frame: :metrics,
-      turbo_action: :advance
+      action: "change->submittable#submit"
     }
   ) do |form| %>
 

--- a/app/views/metrics/_tile.html.erb
+++ b/app/views/metrics/_tile.html.erb
@@ -5,6 +5,9 @@
       content: polaris_icon(name: "ViewMinor", color: :subdued),
       title: "View chart",
       url: url_for(action: action_name, **filter.to_param.merge(chart: tile.handle)),
+      data: {
+        turbo_action: "advance",
+      },
     }]
   ) do %>
       <%= polaris_stack(alignment: :center) do |stack| %>

--- a/app/views/metrics/_tile.html.erb
+++ b/app/views/metrics/_tile.html.erb
@@ -5,10 +5,6 @@
       content: polaris_icon(name: "ViewMinor", color: :subdued),
       title: "View chart",
       url: url_for(action: action_name, **filter.to_param.merge(chart: tile.handle)),
-      data: {
-        turbo_frame: "metrics",
-        turbo_action: "advance",
-      },
     }]
   ) do %>
       <%= polaris_stack(alignment: :center) do |stack| %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "shared/page_actions", page: page %>
 
-  <%= turbo_frame_tag :metrics, data: { controller: "loading" } do %>
+  <%= tag.div data: { controller: "loading" } do %>
 
     <%= polaris_vertical_stack(gap: "6") do %>
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "shared/page_actions", page: page %>
 
-  <%= tag.div data: { controller: "loading" } do %>
+  <%= turbo_frame_tag :metrics, data: { controller: "loading" } do %>
 
     <%= polaris_vertical_stack(gap: "6") do %>
 


### PR DESCRIPTION
Prototype where we remvoe turbo_frames and rely on morphing instead.

- [x] Remove metrics frame
- [x] Check if filters work exactly the same and preserve scroll
- [ ] Normal navigation (to another page) now does not scroll to top, so need to check how to tell it when to preserve scroll or not
- [ ] Get Chartkick reacting to events again (not turbo's fault) 

EDIT: I think it's actually not morphing but instead replacing body like normal navigation 😅