### PR TITLE
Add smiirl integration api endpoint

### DIFF
--- a/app/controllers/public/smiirl_controller.rb
+++ b/app/controllers/public/smiirl_controller.rb
@@ -7,7 +7,7 @@ class Public::SmiirlController < ActionController::API
     end
 
     count_value = compute_count(@integration)
-    render json: { count: count_value }
+    render json: {count: count_value}
   end
 
   private
@@ -20,25 +20,13 @@ class Public::SmiirlController < ActionController::API
 
   def compute_count(integration)
     user = integration.user
-    end_date = user.newest_metric_date_or_today
-    start_date = end_date - 29.days
+    return 0 if user.blank?
 
     case integration.metric_type
-    when "total_revenue_30d"
-      # Sum revenue from metrics for last 30 days, all charge types that are displayable
-      user.metrics
-        .where(metric_date: start_date..end_date)
-        .where(charge_type: Metric::CHARGE_TYPES - ["refund"])
-        .sum(:revenue).to_i
-    else # "paying_users_30d"
-      # Count distinct shops with positive revenue over last 30 days
-      user.payments
-        .where(payment_date: start_date..end_date)
-        .where(charge_type: Metric::CHARGE_TYPES - ["refund"])
-        .where("revenue > 0")
-        .distinct
-        .count(:shop)
+    when "paying_users_30d"
+      user.paying_users_30d.to_i
+    else # "total_revenue_30d"
+      user.total_revenue_30d.to_i
     end
   end
 end
-

--- a/app/controllers/public/smiirl_controller.rb
+++ b/app/controllers/public/smiirl_controller.rb
@@ -1,0 +1,44 @@
+class Public::SmiirlController < ActionController::API
+  before_action :set_integration
+
+  def show
+    unless @integration.enabled?
+      head :not_found and return
+    end
+
+    count_value = compute_count(@integration)
+    render json: { count: count_value }
+  end
+
+  private
+
+  def set_integration
+    @integration = SmiirlIntegration.find_by!(token: params[:token])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def compute_count(integration)
+    user = integration.user
+    end_date = user.newest_metric_date_or_today
+    start_date = end_date - 29.days
+
+    case integration.metric_type
+    when "total_revenue_30d"
+      # Sum revenue from metrics for last 30 days, all charge types that are displayable
+      user.metrics
+        .where(metric_date: start_date..end_date)
+        .where(charge_type: Metric::CHARGE_TYPES - ["refund"])
+        .sum(:revenue).to_i
+    else # "paying_users_30d"
+      # Count distinct shops with positive revenue over last 30 days
+      user.payments
+        .where(payment_date: start_date..end_date)
+        .where(charge_type: Metric::CHARGE_TYPES - ["refund"])
+        .where("revenue > 0")
+        .distinct
+        .count(:shop)
+    end
+  end
+end
+

--- a/app/controllers/smiirl_integrations_controller.rb
+++ b/app/controllers/smiirl_integrations_controller.rb
@@ -2,20 +2,20 @@ class SmiirlIntegrationsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_smiirl_integration
 
-  def show
+  def edit
   end
 
   def update
     if @smiirl_integration.update(smiirl_integration_params)
-      redirect_to smiirl_integration_path, notice: t("actions.saved")
+      redirect_to smiirl_integration_path, notice: "Smiirl integration updated."
     else
-      render :show, status: :unprocessable_entity
+      render :edit, status: :unprocessable_entity
     end
   end
 
   def rotate_token
     @smiirl_integration.rotate_token!
-    redirect_to smiirl_integration_path, notice: t("actions.saved")
+    redirect_to smiirl_integration_path, notice: "Smiirl integration token rotated."
   end
 
   private
@@ -28,4 +28,3 @@ class SmiirlIntegrationsController < ApplicationController
     params.require(:smiirl_integration).permit(:enabled, :metric_type)
   end
 end
-

--- a/app/controllers/smiirl_integrations_controller.rb
+++ b/app/controllers/smiirl_integrations_controller.rb
@@ -7,7 +7,7 @@ class SmiirlIntegrationsController < ApplicationController
 
   def update
     if @smiirl_integration.update(smiirl_integration_params)
-      redirect_to smiirl_integration_path, notice: "Smiirl integration updated."
+      redirect_to edit_smiirl_integration_path, notice: "Smiirl integration updated."
     else
       render :edit, status: :unprocessable_entity
     end
@@ -15,7 +15,7 @@ class SmiirlIntegrationsController < ApplicationController
 
   def rotate_token
     @smiirl_integration.rotate_token!
-    redirect_to smiirl_integration_path, notice: "Smiirl integration token rotated."
+    redirect_to edit_smiirl_integration_path, notice: "Smiirl integration token rotated."
   end
 
   private

--- a/app/controllers/smiirl_integrations_controller.rb
+++ b/app/controllers/smiirl_integrations_controller.rb
@@ -1,0 +1,31 @@
+class SmiirlIntegrationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_smiirl_integration
+
+  def show
+  end
+
+  def update
+    if @smiirl_integration.update(smiirl_integration_params)
+      redirect_to smiirl_integration_path, notice: t("actions.saved")
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  def rotate_token
+    @smiirl_integration.rotate_token!
+    redirect_to smiirl_integration_path, notice: t("actions.saved")
+  end
+
+  private
+
+  def set_smiirl_integration
+    @smiirl_integration = current_user.smiirl_integration || current_user.build_smiirl_integration
+  end
+
+  def smiirl_integration_params
+    params.require(:smiirl_integration).permit(:enabled, :metric_type)
+  end
+end
+

--- a/app/models/metric/tile_presenter.rb
+++ b/app/models/metric/tile_presenter.rb
@@ -18,7 +18,7 @@ class Metric::TilePresenter
       .by_optional_charge_type(@charge_type)
       .by_optional_is_yearly_revenue(@is_yearly_revenue)
       .calculate_value(@calculation, @column)
-    metrics.blank? ? 0 : metrics
+    metrics.presence || 0
   end
 
   def previous_value
@@ -26,7 +26,7 @@ class Metric::TilePresenter
       .by_optional_charge_type(@charge_type)
       .by_optional_is_yearly_revenue(@is_yearly_revenue)
       .calculate_value(@calculation, @column)
-    metrics.blank? ? 0 : metrics
+    metrics.presence || 0
   end
 
   def change

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -8,5 +8,10 @@ class Payment < ApplicationRecord
     def by_optional_app_title(app_title)
       app_title.blank? ? all : where(app_title: app_title)
     end
+
+    def by_date_and_period(date:, period:)
+      previous_period = date - period.days + 1
+      where(payment_date: previous_period.beginning_of_day..date.end_of_day)
+    end
   end
 end

--- a/app/models/smiirl_integration.rb
+++ b/app/models/smiirl_integration.rb
@@ -1,0 +1,31 @@
+class SmiirlIntegration < ApplicationRecord
+  METRIC_TYPES = [
+    "paying_users_30d",
+    "total_revenue_30d"
+  ].freeze
+
+  belongs_to :user
+
+  validates :token, presence: true, length: { minimum: 32 }, uniqueness: true
+  validates :metric_type, inclusion: { in: METRIC_TYPES }
+
+  before_validation :ensure_token
+
+  def rotate_token!
+    update!(token: self.class.generate_unique_token)
+  end
+
+  def self.generate_unique_token
+    loop do
+      token = SecureRandom.hex(16) # 32 chars
+      break token unless exists?(token: token)
+    end
+  end
+
+  private
+
+  def ensure_token
+    self.token ||= self.class.generate_unique_token
+  end
+end
+

--- a/app/models/smiirl_integration.rb
+++ b/app/models/smiirl_integration.rb
@@ -6,8 +6,8 @@ class SmiirlIntegration < ApplicationRecord
 
   belongs_to :user
 
-  validates :token, presence: true, length: { minimum: 32 }, uniqueness: true
-  validates :metric_type, inclusion: { in: METRIC_TYPES }
+  validates :token, presence: true, length: {minimum: 32}, uniqueness: true
+  validates :metric_type, inclusion: {in: METRIC_TYPES}
 
   before_validation :ensure_token
 
@@ -28,4 +28,3 @@ class SmiirlIntegration < ApplicationRecord
     self.token ||= self.class.generate_unique_token
   end
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :metrics, dependent: :delete_all
   has_many :imports, dependent: :delete_all
   has_one :partner_api_credential, dependent: :destroy
+  has_one :smiirl_integration, dependent: :destroy
 
   # TODO: These should probably be in metric model
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,17 +37,15 @@ class User < ApplicationRecord
   # TODO: DRY the following methods up
 
   def total_revenue_30d
-    date = user.newest_metric_date
-    return 0 if date.blank?
+    return 0 if newest_metric_date.blank?
 
-    metrics.by_date_and_period(date: date, period: 30).sum(:revenue)
+    metrics.by_date_and_period(date: newest_metric_date, period: 30).sum(:revenue)
   end
 
   def paying_users_30d
-    date = user.newest_metric_date
-    return 0 if date.blank?
+    return 0 if newest_metric_date.blank?
 
-    payments.by_date_and_period(date: date, period: 30).distinct.count(:shop)
+    payments.by_date_and_period(date: newest_metric_date, period: 30).distinct.count(:shop)
   end
 
   def yearly_revenue_per_product(date:, charge_type: nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,20 @@ class User < ApplicationRecord
 
   # TODO: DRY the following methods up
 
+  def total_revenue_30d
+    date = user.newest_metric_date
+    return 0 if date.blank?
+
+    metrics.by_date_and_period(date: date, period: 30).sum(:revenue)
+  end
+
+  def paying_users_30d
+    date = user.newest_metric_date
+    return 0 if date.blank?
+
+    payments.by_date_and_period(date: date, period: 30).distinct.count(:shop)
+  end
+
   def yearly_revenue_per_product(date:, charge_type: nil)
     if charge_type
       metrics.where(metric_date: 12.months.ago..date, charge_type: charge_type)

--- a/app/views/layouts/frame/_navigation.html.erb
+++ b/app/views/layouts/frame/_navigation.html.erb
@@ -49,10 +49,10 @@
         link_arguments: {}
       ) %>
       <% section.with_item(
-        url: smiirl_integration_path,
+        url: edit_smiirl_integration_path,
         label: "Smiirl integration",
         icon: "GlobeMinor",
-        selected: nav_item_selected?(smiirl_integration_path),
+        selected: nav_item_selected?(edit_smiirl_integration_path),
         link_arguments: {}
       ) %>
       <% section.with_item(

--- a/app/views/layouts/frame/_navigation.html.erb
+++ b/app/views/layouts/frame/_navigation.html.erb
@@ -49,6 +49,13 @@
         link_arguments: {}
       ) %>
       <% section.with_item(
+        url: smiirl_integration_path,
+        label: "Smiirl integration",
+        icon: "GlobeMinor",
+        selected: nav_item_selected?(smiirl_integration_path),
+        link_arguments: {}
+      ) %>
+      <% section.with_item(
         url: partner_api_credential_path_for(current_user),
         label: "Partner API Credentials",
         icon: "InsertDynamicSourceMajor",

--- a/app/views/smiirl_integrations/edit.html.erb
+++ b/app/views/smiirl_integrations/edit.html.erb
@@ -3,6 +3,14 @@
   title: "Smiirl integration",
   subtitle: "Expose a public counter endpoint for your account",
   back_url: imports_path,
+  secondary_actions: @smiirl_integration.persisted? ? [
+    {
+      content: "Rotate token",
+      destructive: true,
+      url: rotate_token_smiirl_integration_path,
+      method: :post
+    }
+  ] : [],
 ) do |page| %>
 
   <%= form_with(
@@ -12,7 +20,9 @@
     builder: Polaris::FormBuilder,
     data: { controller: "form" }
   ) do |form| %>
+
     <%= polaris_layout do |layout| %>
+      <%# Required to submit form via Return/Enter %>
       <%= form.submit hidden: true %>
 
       <% if @smiirl_integration.errors.any? %>
@@ -22,10 +32,11 @@
       <% end %>
 
       <% layout.with_section do %>
-        <%= polaris_card(sectioned: true) do %>
+        <%= polaris_card do %>
           <%= polaris_form_layout do |form_layout| %>
+
             <% form_layout.with_item do %>
-              <%= form.polaris_checkbox :enabled, label: "Enable public endpoint" %>
+              <%= form.polaris_check_box :enabled, label: "Enable public endpoint" %>
             <% end %>
 
             <% form_layout.with_item do %>
@@ -36,26 +47,30 @@
             <% end %>
 
             <% if @smiirl_integration.persisted? %>
-              <% endpoint_url = public_smiirl_url(token: @smiirl_integration.token) %>
               <% form_layout.with_item do %>
-                <%= polaris_text_field :endpoint_url,
-                  label: "Endpoint URL",
+                <% endpoint_url = public_smiirl_url(token: @smiirl_integration.token, format: :json) %>
+                <%= polaris_text_field(label: "Endpoint URL",
                   value: endpoint_url,
                   disabled: true,
-                  help_text: "Copy this URL into your Smiirl dashboard",
+                  help_text: "Copy this URL into your <a href='https://my.smiirl.com/' target='_blank'>Smiirl dashboard</a>".html_safe,
                   connected_right: polaris_button(url: endpoint_url, external: true) { "Open" }
-                %>
+                ) %>
               <% end %>
             <% end %>
 
             <% form_layout.with_item do %>
-              <%= polaris_button(submit: true, primary: true) { t('actions.save') } %>
-              <%= polaris_button(url: rotate_token_smiirl_integration_path, method: :post, destructive: true, disabled: !@smiirl_integration.persisted?) { "Rotate token" } %>
+              <%= polaris_button(
+                submit: true,
+                primary: true,
+                data: {form_target: "submitButton"},
+              ) { t('actions.save') } %>
             <% end %>
+
           <% end %>
         <% end %>
       <% end %>
+
     <% end %>
+
   <% end %>
 <% end %>
-

--- a/app/views/smiirl_integrations/show.html.erb
+++ b/app/views/smiirl_integrations/show.html.erb
@@ -1,0 +1,61 @@
+<%= polaris_page(
+  narrow_width: true,
+  title: "Smiirl integration",
+  subtitle: "Expose a public counter endpoint for your account",
+  back_url: imports_path,
+) do |page| %>
+
+  <%= form_with(
+    model: @smiirl_integration,
+    url: smiirl_integration_path,
+    method: :put,
+    builder: Polaris::FormBuilder,
+    data: { controller: "form" }
+  ) do |form| %>
+    <%= polaris_layout do |layout| %>
+      <%= form.submit hidden: true %>
+
+      <% if @smiirl_integration.errors.any? %>
+        <% layout.with_section do %>
+          <%= form.errors_summary %>
+        <% end %>
+      <% end %>
+
+      <% layout.with_section do %>
+        <%= polaris_card(sectioned: true) do %>
+          <%= polaris_form_layout do |form_layout| %>
+            <% form_layout.with_item do %>
+              <%= form.polaris_checkbox :enabled, label: "Enable public endpoint" %>
+            <% end %>
+
+            <% form_layout.with_item do %>
+              <%= form.polaris_select :metric_type,
+                label: "Metric to expose",
+                options: [["Paying users (30 days)", "paying_users_30d"], ["Total revenue (30 days)", "total_revenue_30d"]]
+              %>
+            <% end %>
+
+            <% if @smiirl_integration.persisted? %>
+              <% endpoint_url = public_smiirl_url(token: @smiirl_integration.token) %>
+              <% form_layout.with_item do %>
+                <%= polaris_text_field :endpoint_url,
+                  label: "Endpoint URL",
+                  value: endpoint_url,
+                  disabled: true,
+                  help_text: "Copy this URL into your Smiirl dashboard",
+                  connected_right: polaris_button(url: endpoint_url, external: true) { "Open" }
+                %>
+              <% end %>
+            <% end %>
+
+            <% form_layout.with_item do %>
+              <%= polaris_button(submit: true, primary: true) { t('actions.save') } %>
+              <%= polaris_button(url: rotate_token_smiirl_integration_path, method: :post, destructive: true, disabled: !@smiirl_integration.persisted?) { "Rotate token" } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+

--- a/config/initializers/generate_test_fixture.rb
+++ b/config/initializers/generate_test_fixture.rb
@@ -36,7 +36,7 @@ class ActiveRecord::Base
 
             blob = attachment.blob
             blob.dump_raw_fixture("#{blob_name}: <%= ActiveStorage::Blob.fixture(filename: '#{blob.filename}') %>\n")
-            blob_path = "#{Rails.root}/test/fixtures/files/#{blob.filename}"
+            blob_path = "#{Rails.root.join("test/fixtures/files/#{blob.filename}")}"
             File.open(blob_path, "wb+") do |file|
               blob.download { |chunk| file.write(chunk) }
             end
@@ -46,7 +46,7 @@ class ActiveRecord::Base
   end
 
   def dump_raw_fixture(text)
-    fixture_file = "#{Rails.root}/test/fixtures/#{self.class.name.underscore.pluralize}.yml"
+    fixture_file = "#{Rails.root.join("test/fixtures/#{self.class.name.underscore.pluralize}.yml")}"
     File.open(fixture_file, "a+") do |f|
       f.puts(text)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :smiirl_integration, only: [:show, :update] do
+  resource :smiirl_integration, only: [:edit, :update] do
     post :rotate_token, on: :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,13 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :smiirl_integration, only: [:show, :update] do
+    post :rotate_token, on: :collection
+  end
+
+  namespace :public do
+    get "/smiirl/:token", to: "smiirl#show", as: :smiirl
+  end
+
   root to: "home#index"
 end

--- a/db/migrate/20250930000000_create_smiirl_integrations.rb
+++ b/db/migrate/20250930000000_create_smiirl_integrations.rb
@@ -1,0 +1,15 @@
+class CreateSmiirlIntegrations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :smiirl_integrations do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.boolean :enabled, null: false, default: false
+      t.string :metric_type, null: false, default: "paying_users_30d"
+      t.string :token, null: false, limit: 64
+
+      t.timestamps
+    end
+
+    add_index :smiirl_integrations, :token, unique: true
+  end
+end
+

--- a/db/migrate/20250930000000_create_smiirl_integrations.rb
+++ b/db/migrate/20250930000000_create_smiirl_integrations.rb
@@ -3,7 +3,7 @@ class CreateSmiirlIntegrations < ActiveRecord::Migration[7.0]
     create_table :smiirl_integrations do |t|
       t.references :user, null: false, foreign_key: true, index: { unique: true }
       t.boolean :enabled, null: false, default: false
-      t.string :metric_type, null: false, default: "paying_users_30d"
+      t.string :metric_type, null: false, default: "total_revenue_30d"
       t.string :token, null: false, limit: 64
 
       t.timestamps
@@ -12,4 +12,3 @@ class CreateSmiirlIntegrations < ActiveRecord::Migration[7.0]
     add_index :smiirl_integrations, :token, unique: true
   end
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_19_173404) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_173404) do
     t.index ["user_id", "payment_date"], name: "index_payments_on_user_id_and_payment_date"
   end
 
+  create_table "smiirl_integrations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "metric_type", default: "total_revenue_30d", null: false
+    t.string "token", limit: 64, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_smiirl_integrations_on_token", unique: true
+    t.index ["user_id"], name: "index_smiirl_integrations_on_user_id", unique: true
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -137,4 +148,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_173404) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "imports", "users"
   add_foreign_key "partner_api_credentials", "users"
+  add_foreign_key "smiirl_integrations", "users"
 end

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -15,7 +15,7 @@ module ShopifyPartnerAPI
     def execute(document:, operation_name: nil, variables: {}, context: {})
       @uri = URI.parse("https://partners.shopify.com/#{context.fetch(:organization_id)}/api/#{SHOPIFY_PARTNER_API_VERSION}/graphql.json")
 
-      super(document: document, operation_name: operation_name, variables: variables, context: context)
+      super
     end
   end
 end

--- a/test/controllers/public_smiirl_controller_test.rb
+++ b/test/controllers/public_smiirl_controller_test.rb
@@ -5,7 +5,7 @@ class PublicSmiirlControllerTest < ActionDispatch::IntegrationTest
     @user = users(:regular)
     @integration = @user.create_smiirl_integration!(enabled: true, metric_type: "paying_users_30d")
     # Ensure payments exist in last 30 days
-    Payment.create!(user: @user, import: imports(:completed), payment_date: Date.today, charge_type: "recurring_revenue", app_title: "x", shop: "a", revenue: 10)
+    Payment.create!(user: @user, import: imports(:completed), payment_date: Time.zone.today, charge_type: "recurring_revenue", app_title: "x", shop: "a", revenue: 10)
   end
 
   test "returns count json when enabled" do

--- a/test/controllers/public_smiirl_controller_test.rb
+++ b/test/controllers/public_smiirl_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class PublicSmiirlControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:regular)
+    @integration = @user.create_smiirl_integration!(enabled: true, metric_type: "paying_users_30d")
+    # Ensure payments exist in last 30 days
+    Payment.create!(user: @user, import: imports(:completed), payment_date: Date.today, charge_type: "recurring_revenue", app_title: "x", shop: "a", revenue: 10)
+  end
+
+  test "returns count json when enabled" do
+    get public_smiirl_url(token: @integration.token)
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal({"count"=>1}, json)
+  end
+
+  test "returns 404 when disabled" do
+    @integration.update!(enabled: false)
+    get public_smiirl_url(token: @integration.token)
+    assert_response :not_found
+  end
+
+  test "returns 404 for unknown token" do
+    get public_smiirl_url(token: "unknown")
+    assert_response :not_found
+  end
+end
+

--- a/test/controllers/public_smiirl_controller_test.rb
+++ b/test/controllers/public_smiirl_controller_test.rb
@@ -12,7 +12,7 @@ class PublicSmiirlControllerTest < ActionDispatch::IntegrationTest
     get public_smiirl_url(token: @integration.token)
     assert_response :success
     json = JSON.parse(response.body)
-    assert_equal({"count"=>1}, json)
+    assert_equal({"count" => 1}, json)
   end
 
   test "returns 404 when disabled" do
@@ -26,4 +26,3 @@ class PublicSmiirlControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 end
-

--- a/test/controllers/smiirl_integrations_controller_test.rb
+++ b/test/controllers/smiirl_integrations_controller_test.rb
@@ -12,7 +12,7 @@ class SmiirlIntegrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update toggles enabled and metric_type" do
-    put smiirl_integration_url, params: { smiirl_integration: { enabled: true, metric_type: "total_revenue_30d" } }
+    put smiirl_integration_url, params: {smiirl_integration: {enabled: true, metric_type: "total_revenue_30d"}}
     assert_redirected_to smiirl_integration_url
     @user.reload
     assert @user.smiirl_integration.enabled?
@@ -28,4 +28,3 @@ class SmiirlIntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal old, @user.smiirl_integration.token
   end
 end
-

--- a/test/controllers/smiirl_integrations_controller_test.rb
+++ b/test/controllers/smiirl_integrations_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SmiirlIntegrationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:regular)
+    sign_in @user
+  end
+
+  test "show renders" do
+    get smiirl_integration_url
+    assert_response :success
+  end
+
+  test "update toggles enabled and metric_type" do
+    put smiirl_integration_url, params: { smiirl_integration: { enabled: true, metric_type: "total_revenue_30d" } }
+    assert_redirected_to smiirl_integration_url
+    @user.reload
+    assert @user.smiirl_integration.enabled?
+    assert_equal "total_revenue_30d", @user.smiirl_integration.metric_type
+  end
+
+  test "rotate token changes token" do
+    @user.create_smiirl_integration!
+    old = @user.smiirl_integration.token
+    post rotate_token_smiirl_integration_url
+    assert_redirected_to smiirl_integration_url
+    @user.reload
+    assert_not_equal old, @user.smiirl_integration.token
+  end
+end
+

--- a/test/controllers/smiirl_integrations_controller_test.rb
+++ b/test/controllers/smiirl_integrations_controller_test.rb
@@ -7,13 +7,13 @@ class SmiirlIntegrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show renders" do
-    get smiirl_integration_url
+    get edit_smiirl_integration_url
     assert_response :success
   end
 
   test "update toggles enabled and metric_type" do
     put smiirl_integration_url, params: {smiirl_integration: {enabled: true, metric_type: "total_revenue_30d"}}
-    assert_redirected_to smiirl_integration_url
+    assert_redirected_to edit_smiirl_integration_url
     @user.reload
     assert @user.smiirl_integration.enabled?
     assert_equal "total_revenue_30d", @user.smiirl_integration.metric_type
@@ -23,7 +23,7 @@ class SmiirlIntegrationsControllerTest < ActionDispatch::IntegrationTest
     @user.create_smiirl_integration!
     old = @user.smiirl_integration.token
     post rotate_token_smiirl_integration_url
-    assert_redirected_to smiirl_integration_url
+    assert_redirected_to edit_smiirl_integration_url
     @user.reload
     assert_not_equal old, @user.smiirl_integration.token
   end

--- a/test/models/smiirl_integration_test.rb
+++ b/test/models/smiirl_integration_test.rb
@@ -22,4 +22,3 @@ class SmiirlIntegrationTest < ActiveSupport::TestCase
     assert_includes integration.errors[:metric_type], "is not included in the list"
   end
 end
-

--- a/test/models/smiirl_integration_test.rb
+++ b/test/models/smiirl_integration_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class SmiirlIntegrationTest < ActiveSupport::TestCase
+  test "generates token on create and rotates token" do
+    user = users(:regular)
+    integration = user.build_smiirl_integration
+    assert integration.valid?
+    integration.save!
+    assert_not_nil integration.token
+    assert_equal 32, integration.token.length
+
+    old_token = integration.token
+    integration.rotate_token!
+    assert_not_equal old_token, integration.token
+    assert_equal 32, integration.token.length
+  end
+
+  test "metric type validation" do
+    user = users(:regular)
+    integration = user.build_smiirl_integration(metric_type: "invalid")
+    assert_not integration.valid?
+    assert_includes integration.errors[:metric_type], "is not included in the list"
+  end
+end
+


### PR DESCRIPTION
Add Smiirl integration to provide users with a public API endpoint for displaying revenue or paying user counts on Smiirl counter devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-f33f9b8f-c67a-4298-9a1c-c9be5be99bc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f33f9b8f-c67a-4298-9a1c-c9be5be99bc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

